### PR TITLE
ci: add GH Actions workflow for flake8 / tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,3 +13,4 @@ exclude =
     dist,
     temp,
     vendor
+inline-quotes = "

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,30 @@
+---
+name: Run flake8 and tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - uses: BSFishy/pip-action@v1
+        with:
+          requirements: requirements-dev.txt
+      - run: python setup.py install
+      - run: python -m flake8
+      - run: python -m pytest -v

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Create a personal [API token](https://circleci.com/docs/2.0/managing-api-tokens/
 ### Contributing
 
 1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+1. Install dev dependencies (`pip install -r requirements-dev.txt`) and `requests` library
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Make sure flake8 and the pytest test suite runs locally
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create new Pull Request

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+flake8
+flake8-quotes
+pytest


### PR DESCRIPTION
Add a matrix to run flake8 and pytest in different versions of Python via GitHub actions